### PR TITLE
Fix support for PHP 7.2

### DIFF
--- a/classes/Archive_Tar.php
+++ b/classes/Archive_Tar.php
@@ -43,7 +43,7 @@ namespace TbUpdaterModule;
 
 // If the PEAR class cannot be loaded via the autoloader,
 // then try to require_once it from the PHP include path.
-if (!class_exists('PsOneSigMigrator\\PEAR')) {
+if (!class_exists('PEAR')) {
     require_once 'PEAR.php';
 }
 
@@ -661,7 +661,7 @@ class Archive_Tar extends PEAR
         }
 
         // ----- Get the arguments
-        $v_att_list = & func_get_args();
+        $v_att_list = func_get_args();
 
         // ----- Read the attributes
         $i = 0;


### PR DESCRIPTION
Just updated the library (https://pear.php.net/package/Archive_Tar/) to the latest version to support PHP 7.2. This is handled by Composer in core.

Also changed the PEAR `class_exists` conditional because it had a typo (should have been `PsOneSixMigrator` and not `Sig`) and it would never trigger. Even if the typo was fixed, it would lead to an error because the class would be namespaced then. So I just reverted it to the original code.